### PR TITLE
Remove ldflags for linux_amd64 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
   - env:
     - goos=linux
     - goarch=amd64
-    - ldflags="-linkmode external -extldflags -static -s -w"
+    - ldflags=""
   - env:
     - goos=linux
     - goarch=arm

--- a/travis/vars.yml
+++ b/travis/vars.yml
@@ -4,7 +4,7 @@
 
 - goos: linux
   goarch: 'amd64'
-  ldflags: '-linkmode external -extldflags -static -s -w'
+  ldflags:
 
 - goos: linux
   goarch: 'arm'


### PR DESCRIPTION
Since the DNS resolution cannot work with pure static linking for when linking against `libc`, which is the case for Travis Go set-up (likely using Debian as the distribution).