### PR TITLE
Fix script for OSX because uname -i doesn't work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 terraform-provider-smallutil
 terraform-provider-smallutil.exe
+terraform-provider-smallutil_*.zip
 
 tf_test/*
 !tf_test/main.tf

--- a/install_from_release.sh
+++ b/install_from_release.sh
@@ -25,7 +25,7 @@ else
   exit 1
 fi
 
-ARCH_CALL="$(uname -i)"
+ARCH_CALL="$(uname -m)"
 if [[ "${ARCH_CALL}" == i*86 ]]; then
   ARCH=386
 elif [[ "${ARCH_CALL}" == x86_64* ]]; then


### PR DESCRIPTION
`uname -m` works and has the same effect for now. Not sure for `arm*`.